### PR TITLE
Improve Assertion Message Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To add the Assertion Tool to your project, follow these steps:
    ```
 2. Import the tool into your test files:
    ```javascript
-   const softAssert = require('klassijs-soft-assert');
+   const { softAssert } = require('klassijs-soft-assert');
    ```
 
 ## Usage

--- a/src/assertExpect.js
+++ b/src/assertExpect.js
@@ -103,7 +103,6 @@ async function softAssert(actual, assertionType, expected, message, operator) {
     if (cucumberThis && cucumberThis.attach) {
       cucumberThis.attach(`<div style="color:red;"> ${errmsg} </div>`);
     }
-    err.message = errmsg;
     errors.push(err);
   }
 }

--- a/src/assertExpect.js
+++ b/src/assertExpect.js
@@ -94,13 +94,16 @@ async function softAssert(actual, assertionType, expected, message, operator) {
     await (getAssertionType[assertionType] || getAssertionType['default'])();
   } catch (err) {
     const filteredActual = typeof actual === 'string' ? actual.replace(/[<>]/g, '') : actual;
-    errmsg =
-      `Assertion Failure: Invalid Assertion Type = ${assertionType}` +
-      '\n' +
-      `Assertion failed: expected ${filteredActual} to ${assertionType} ${expected}`;
+    let errmsg;
+    if (message) {
+      errmsg = `${message} (Assertion failed: expected ${filteredActual} to ${operator ? operator : assertionType}${expected ? ' '+expected : ''})`;
+    } else {
+      errmsg = `Assertion failed: expected ${filteredActual} to ${operator ? operator : assertionType}${expected ? ' '+expected : ''}`;
+    }
     if (cucumberThis && cucumberThis.attach) {
       cucumberThis.attach(`<div style="color:red;"> ${errmsg} </div>`);
     }
+    err.message = errmsg;
     errors.push(err);
   }
 }
@@ -140,7 +143,7 @@ function throwCollectedErrors() {
     const cleanConsoleOutput = consoleOutput.replace(/\x1b\[[0-9;]*m/g, ''); // Remove color codes
     const consoleMessage = `<div style="color:red;">${fullErrorMessage}</div>\n${cleanConsoleOutput}`;
     if (cucumberThis && cucumberThis.attach) {
-      cucumberThis.attach(`Attachment (text/plain): ${consoleMessage}`);
+      cucumberThis.attach(`${fullErrorMessage}\n${cleanConsoleOutput}`);
     }
     throw new Error(consoleMessage);
   }

--- a/src/assertExpect.js
+++ b/src/assertExpect.js
@@ -142,7 +142,7 @@ function throwCollectedErrors() {
     const cleanConsoleOutput = consoleOutput.replace(/\x1b\[[0-9;]*m/g, ''); // Remove color codes
     const consoleMessage = `<div style="color:red;">${fullErrorMessage}</div>\n${cleanConsoleOutput}`;
     if (cucumberThis && cucumberThis.attach) {
-      cucumberThis.attach(`${fullErrorMessage}\n${cleanConsoleOutput}`);
+      cucumberThis.attach(`${consoleMessage}`);
     }
     errors.length = 0; // Empty error buffer
     throw new Error(consoleMessage);


### PR DESCRIPTION
This PR primarily includes changes to assertion failure output, so that `message` and `operator` are now used. It also corrects minor README.md inaccuracy, and tidies up report output slightly.

1. `message`, if provided, now displays before `Assertion failed: [...]`
2. `operator`, if provided, replaces `assertionType` in failure message
3. `expected` is not printed if it is not provided

The output of:
`await softAssert(true, 'isFalse', null, 'Message explaining what failed', 'be false');`
... goes from:
`Assertion failed: expected true to isFalse null`
... to:
`Message explaining what failed (Assertion failed: expected true to be false)`

Error messages thrown in `throwCollectedErrors` are unmodified, so technical information remains available.